### PR TITLE
Fix tests to have Avro 1.8.0 compliant schemas

### DIFF
--- a/test/alias-fixed/union.avsc
+++ b/test/alias-fixed/union.avsc
@@ -16,7 +16,6 @@
           {
               "name": "id",
               "type": "string",
-              "logicalType": "uuid",
               "doc": "Unique ID for this event."
           },
           {

--- a/test/union-root-short/union.avsc
+++ b/test/union-root-short/union.avsc
@@ -20,7 +20,6 @@
           {
               "name": "id",
               "type": "string",
-              "logicalType": "uuid",
               "doc": "Unique ID for this event.",
               "metadata": {
                 "key": "field1"

--- a/test/union-root/union.avsc
+++ b/test/union-root/union.avsc
@@ -20,7 +20,6 @@
           {
               "name": "id",
               "type": "string",
-              "logicalType": "uuid",
               "doc": "Unique ID for this event.",
               "metadata": {
                 "key": "field1"


### PR DESCRIPTION
Remove the `logicalType: uuid` attribute from fields
since this isn't a real logicalType and it breaks
decoding of our OCF files in goavro.